### PR TITLE
Same tab tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ export class AppComponent {
     }
     
      tabSelected(args: SelectedIndexChangedEventData) {
-         // only triggered when a different tab is tapped
          console.log(args.newIndex);
      }
 }
@@ -129,7 +128,6 @@ export class HomeViewModel extends Observable {
     }
 
     tabSelected(args: SelectedIndexChangedEventData) {
-        // only triggered when a different tab is tapped
         console.log(args.newIndex);
     }
 }

--- a/src/android/bottombar.ts
+++ b/src/android/bottombar.ts
@@ -45,7 +45,7 @@ export class BottomBar extends BottomBarBase {
             },
             onTabSelected: function (position: number, wasSelected: boolean): boolean {
 
-                if (this.owner && !wasSelected) {
+                if (this.owner) {
 
                     var eventData: SelectedIndexChangedEventData = {
                         eventName: "tabSelected",


### PR DESCRIPTION
Tapping on selected tab triggers `tabSelected`
Also updated readme - remove comment on `tabSelected`

Fixes #73 for android, 
See https://github.com/rhanb/MiniTabBar/pull/3 for ios